### PR TITLE
chore: update output message

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -165,7 +165,7 @@ const main = defineCommand({
 
           console.log("\n");
           console.log(
-            `⚡️ Your npm packages are published.\n${[...formData.keys()].map((name, i) => `${name}: \`npm i ${laterRes.urls[i]}\``).join("\n")}`,
+            `⚡️ Your npm packages are published.\n${[...formData.keys()].map((name, i) => `${name}: npm i ${laterRes.urls[i]}`).join("\n")}`,
           );
         },
       };


### PR DESCRIPTION
Remove the backticks that surround the command `npm i ...` in output messages.

The reason is that when the message is printed as the output of a step in the workflow, the trailing backtick will be regarded as a part of the clickable link. So when a user clicks it, the browser will open a wrong link (with the trailing backtick encoded to `%60` and appended to that link) and reports a 404 error.

[![image](https://github.com/stackblitz-labs/pkg.pr.new/assets/10386119/67cfcfc9-bb99-4a54-8934-23b07f7c9b2d)](https://github.com/biomejs/biome/actions/runs/9206513359/job/25360381248#step:8:17)
