### PR TITLE
fix: conflict on run id

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pkg.pr.new uses `npm pack --json` under the hood, in case you face issues, you c
 
 <img width="100%" src="https://github.com/stackblitz-labs/pkg.pr.new/assets/37929992/2fc03b94-ebae-4c47-a271-03a4ad5d2449" />
 
-pkg.pr.new is not available in your local environment and it only works in workflows.
+pkg.pr.new is not available in your local environment and it only works in workflows since it is not a js registry. 
 
 ### Examples
 

--- a/e2e/publish.test.mts
+++ b/e2e/publish.test.mts
@@ -72,6 +72,7 @@ for (const [{ payload }, pr] of [
       GITHUB_ACTOR_ID: payload.sender.id,
       GITHUB_SHA: payload.workflow_job.head_sha,
       GITHUB_ACTION: payload.workflow_job.id,
+      GITHUB_JOB: payload.workflow_job.name,
       GITHUB_REF_NAME: pr
         ? `${pr.payload.number}/merge`
         : payload.workflow_job.head_branch,

--- a/packages/backend/server/routes/webhook.post.ts
+++ b/packages/backend/server/routes/webhook.post.ts
@@ -29,8 +29,8 @@ export default eventHandler(async (event) => {
     const metadata = {
       owner,
       repo,
+      job: payload.workflow_job.name,
       runId: payload.workflow_job.run_id,
-      jobId: payload.workflow_job.id,
       attempt: payload.workflow_job.run_attempt,
       actor: payload.sender.id,
     };

--- a/packages/cli/environments.ts
+++ b/packages/cli/environments.ts
@@ -25,6 +25,8 @@ declare global {
       GITHUB_EVENT_PATH: string;
       // A unique number for each workflow run within a repository. This number does not change if you re-run the workflow run. For example, 1658821493.
       GITHUB_RUN_ID: string;
+      // The job_id of the current job. For example, greeting_job.
+      GITHUB_JOB: string;
       // A unique number for each attempt of a particular workflow run in a repository. This number begins at 1 for the workflow run's first attempt, and increments with each re-run. For example, 3.
       GITHUB_RUN_ATTEMPT: string;
     }

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -71,28 +71,31 @@ const main = defineCommand({
             );
             process.exit(1);
           }
-          const octokit = new Octokit();
+
+          new Octokit(); // gh authentication
 
           const {
-            GITHUB_SERVER_URL,
             GITHUB_REPOSITORY,
             GITHUB_RUN_ID,
             GITHUB_RUN_ATTEMPT,
             GITHUB_ACTOR_ID,
+            GITHUB_JOB
           } = process.env;
 
           const [owner, repo] = GITHUB_REPOSITORY.split("/");
 
-          // Note: If you need to use a workflow run's URL from within a job, you can combine these variables: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-          const url = `${GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${GITHUB_RUN_ID}`;
-
           const metadata = {
-            url,
+            owner,
+            repo,
+            runId: GITHUB_RUN_ID,
+            jobId: GITHUB_JOB,
             attempt: Number(GITHUB_RUN_ATTEMPT),
             actor: Number(GITHUB_ACTOR_ID),
           };
 
+          console.log('metadata', metadata)
           const key = hash(metadata);
+          console.log('key', key)
 
           const checkResponse = await fetch(new URL("/check", API_URL), {
             method: "POST",

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -88,7 +88,7 @@ const main = defineCommand({
             owner,
             repo,
             job: GITHUB_JOB,
-            runId: GITHUB_RUN_ID,
+            runId: Number(GITHUB_RUN_ID),
             attempt: Number(GITHUB_RUN_ATTEMPT),
             actor: Number(GITHUB_ACTOR_ID),
           };

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -94,6 +94,7 @@ const main = defineCommand({
           };
 
           console.log('metadata', metadata)
+          console.log(process.env)
           const key = hash(metadata);
           console.log('key', key)
 

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -1,4 +1,4 @@
-import { defineCommand, runMain, parseArgs } from "citty";
+import { defineCommand, runMain } from "citty";
 import assert from "node:assert";
 import path from "path";
 import ezSpawn from "@jsdevtools/ez-spawn";
@@ -87,8 +87,8 @@ const main = defineCommand({
           const metadata = {
             owner,
             repo,
+            job: GITHUB_JOB,
             runId: GITHUB_RUN_ID,
-            jobId: GITHUB_JOB,
             attempt: Number(GITHUB_RUN_ATTEMPT),
             actor: Number(GITHUB_ACTOR_ID),
           };


### PR DESCRIPTION
The issue happens here https://github.com/QwikDev/qwik/pull/6389

when other workflows finish, the workflow key would be removed since they all share the same workflow key. And when it is removed, the publish step would crash since there is not workflow key for that step.

what I'm trying to do here is to make the workflow key unique to each step.