### PR TITLE
fix: proper key for pull request event

### DIFF
--- a/packages/backend/server/routes/webhook.post.ts
+++ b/packages/backend/server/routes/webhook.post.ts
@@ -2,7 +2,6 @@ import type { PullRequestEvent } from "@octokit/webhooks-types";
 import type { HandlerFunction } from "@octokit/webhooks/dist-types/types";
 import type { PullRequestData, WorkflowData } from "../types";
 import { hash } from "ohash";
-import { abbreviateCommitHash } from "@pkg-pr-new/utils";
 
 // mark a PR as a PR :)
 const prMarkEvents: PullRequestEvent["action"][] = [
@@ -40,9 +39,8 @@ export default eventHandler(async (event) => {
       // "requested" or "in_progress"
       // "requested" won't be received in re-running workflow jobs, but "in_progress" would be
       const prData: PullRequestData = {
-        owner,
-        repo,
-        ref: payload.workflow_run.head_branch!,
+        full_name: payload.workflow_run.head_repository.full_name,
+        ref: payload.workflow_run.head_branch,
       };
       const prDataHash = hash(prData);
       const isPullRequest = await pullRequestNumbersBucket.hasItem(prDataHash);
@@ -69,8 +67,7 @@ export default eventHandler(async (event) => {
     const [owner, repo] = payload.repository.full_name.split("/");
     // TODO: functions that generate these kinda keys
     const key: PullRequestData = {
-      owner,
-      repo,
+      full_name: payload.pull_request.head.repo?.full_name!,
       ref: payload.pull_request.head.ref,
     };
     const prDataHash = hash(key);
@@ -80,14 +77,27 @@ export default eventHandler(async (event) => {
       await pullRequestNumbersBucket.removeItem(prDataHash);
 
       const baseKey = `${owner}:${repo}`;
-      const cursorKey = `${baseKey}:${payload.pull_request.head.ref}`;
+      const cursorKey = `${baseKey}:${payload.number}`;
 
       await cursorBucket.removeItem(cursorKey);
     }
   };
 
+  const branchDeletionHandler: HandlerFunction<"delete", unknown> = async ({
+    payload,
+  }) => {
+    const [owner, repo] = payload.repository.full_name.split("/");
+
+    const baseKey = `${owner}:${repo}`;
+    const cursorKey = `${baseKey}:${payload.ref}`;
+
+    await cursorBucket.removeItem(cursorKey);
+  }
+  
+
   app.webhooks.on("workflow_run", workflowHandler);
   app.webhooks.on("pull_request", pullRequestHandler);
+  app.webhooks.on("delete", branchDeletionHandler)
 
   type EmitterWebhookEvent = Parameters<
     typeof app.webhooks.receive | typeof app.webhooks.verifyAndReceive
@@ -123,5 +133,6 @@ export default eventHandler(async (event) => {
   } finally {
     app.webhooks.removeListener("workflow_run", workflowHandler);
     app.webhooks.removeListener("pull_request", pullRequestHandler);
+    app.webhooks.removeListener("delete", branchDeletionHandler);
   }
 });

--- a/packages/backend/server/types.ts
+++ b/packages/backend/server/types.ts
@@ -5,7 +5,10 @@ export type WorkflowData = {
   ref: string;
 };
 
-export type PullRequestData = Omit<WorkflowData, 'sha'>
+export type PullRequestData = {
+  full_name: string,
+  ref: string
+}
 
 export type Cursor = {
   timestamp: number;

--- a/packages/backend/server/utils/markdown.ts
+++ b/packages/backend/server/utils/markdown.ts
@@ -54,7 +54,7 @@ export function generatePullRequestPublishMessage(
         workflowData,
         compact,
       );
-      return `#### ${packageName} ([\`${workflowData.sha}\`](${checkRunUrl}))
+      return `#### ${packageName} ([\`${abbreviateCommitHash(workflowData.sha)}\`](${checkRunUrl}))
 \`\`\`
 npm i ${refUrl}
 \`\`\``;

--- a/packages/backend/server/utils/markdown.ts
+++ b/packages/backend/server/utils/markdown.ts
@@ -1,3 +1,4 @@
+import { abbreviateCommitHash } from "@pkg-pr-new/utils";
 import { WorkflowData } from "../types";
 
 export function generateCommitPublishMessage(
@@ -95,7 +96,7 @@ export function generatePublishUrl(
   workflowData: WorkflowData,
   compact: boolean,
 ) {
-  const tag = base === "sha" ? workflowData.sha : workflowData.ref;
+  const tag = base === "sha" ? abbreviateCommitHash(workflowData.sha) : workflowData.ref;
   const shorter = workflowData.repo === packageName;
 
   const urlPath = compact


### PR DESCRIPTION
Now vite main branch points to https://github.com/vitejs/vite/pull/17438 because of the pr key collision.