### PR TITLE
fix: Safely pass glob pattern args as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install --save-dev pkg-pr-new # or `npx pkg-pr-new publish`
 For workspaces:
 
 ```sh
-npx pkg-pr-new publish ./packages/A ./packages/B # or `npx pkg-pr-new publish ./packages/*`
+npx pkg-pr-new publish './packages/A' './packages/B' # or `npx pkg-pr-new publish './packages/*'`
 ```
 
 For templates (experimental):
@@ -51,7 +51,7 @@ For templates (experimental):
 > With templates, pkg.pr.new will generate Stackblitz instances for the given directories with the new built packages.
 
 ```sh
-npx pkg-pr-new publish ./packages/A --template="./examples/*"
+npx pkg-pr-new publish './packages/A' --template './examples/*'
 ```
 
 By default, pkg.pr.new will generate a template called "default" which includes each built package in the dependencies. This can be disabled with `--no-template`.
@@ -59,7 +59,7 @@ By default, pkg.pr.new will generate a template called "default" which includes 
 For shorter urls, `--compact` can be useful:
 
 ```sh
-npx pkg-pr-new publish --compact ./packages/A ./packages/B
+npx pkg-pr-new publish --compact './packages/A' './packages/B'
 ```
 
 > `--compact` requires your package to be a valid (published) package on npm with a specified `repository` field in the package.json! See [this](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "pnpm -r run dev",
     "build": "pnpm -r run build",
-    "publish:playgrounds": "pnpm pkg-pr-new publish ./playgrounds/* ./packages/cli --template=\"./templates/*\"",
+    "publish:playgrounds": "pnpm pkg-pr-new publish './playgrounds/*' './packages/cli' --template './templates/*'",
     "format": "prettier --write --cache .",
     "lint": "eslint --cache .",
     "typecheck": "tsc -p scripts --noEmit && pnpm -r --parallel run typecheck",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "pnpm -r run dev",
     "build": "pnpm -r run build",
-    "publish:playgrounds": "pnpm pkg-pr-new publish './playgrounds/*' './packages/cli' --template './templates/*'",
+    "publish:playgrounds": "pnpm pkg-pr-new publish './playgrounds/*' ./packages/cli --template './templates/*'",
     "format": "prettier --write --cache .",
     "lint": "eslint --cache .",
     "typecheck": "tsc -p scripts --noEmit && pnpm -r --parallel run typecheck",

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -59,7 +59,6 @@ const main = defineCommand({
           },
         },
         run: async ({ args }) => {
-          console.log(args);
           const paths = (args._.length ? args._ : ["."])
             .flatMap((p) => fg.sync(p, { onlyDirectories: true }))
             .map((p) => path.resolve(p.trim()));

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -59,12 +59,9 @@ const main = defineCommand({
           },
         },
         run: async ({ args }) => {
+          console.log(args);
           const paths = (args._.length ? args._ : ["."])
-            .flatMap((p) =>
-              fg.isDynamicPattern(p)
-                ? fg.sync(p, { onlyDirectories: true })
-                : p,
-            )
+            .flatMap((p) => fg.sync(p, { onlyDirectories: true }))
             .map((p) => path.resolve(p.trim()));
 
           const templates = (
@@ -72,11 +69,7 @@ const main = defineCommand({
               ? [args.template]
               : ([...(args.template || [])] as string[])
           )
-            .flatMap((p) =>
-              fg.isDynamicPattern(p)
-                ? fg.sync(p, { onlyDirectories: true })
-                : p,
-            )
+            .flatMap((p) => fg.sync(p, { onlyDirectories: true }))
             .map((p) => path.resolve(p.trim()));
 
           const formData = new FormData();

--- a/packages/cli/template.ts
+++ b/packages/cli/template.ts
@@ -28,7 +28,7 @@ npm i ${url}
 To use this feature as a maintainer, you can run the following command:
 
 \`\`\`sh
-npx pkg-pr-new publish ./packages/A --template="./examples/*"
+npx pkg-pr-new publish './packages/A' --template './examples/*'
 \`\`\`
 
 ## Benefits


### PR DESCRIPTION
As I learnt while debugging #136, different shell environments will parse glob patterns differently (https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784)

This PR updates the docs to pass all packages/templates as strings, to help other users avoid the unexpected behaviour I encountered.

It also removes the `fg.isDynamicPattern` check, since passing a non-dynamic path to `fg.sync` doesn't alter the path. This is solely a readability change and I'm happy to undo it if you want!