### PR TITLE
set `repository` field in cli package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,6 +7,11 @@
   "bin": {
     "pkg-pr-new": "bin/cli.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stackblitz-labs/pkg.pr.new",
+    "directory": "packages/cli"
+  },
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",


### PR DESCRIPTION
The instructions say to run `pnpx pkg-pr-new` but when you check that out on https://npmjs.com/package/pkg-pr-new you see v little reassuring information pointing back here. So if reading a GitHub Action which uses this, it's hard to find where it comes from.

This adds `repository` to the CLI package. I haven't looked at the other packages but probably they could get the same treatment. Happy to add them to this PR if maintainers would want that.