### PR TITLE
feat: support bun in the PR comments

### DIFF
--- a/packages/backend/server/utils/markdown.ts
+++ b/packages/backend/server/utils/markdown.ts
@@ -5,6 +5,7 @@ const packageCommands: Record<PackageManager, string> = {
   npm: "i",
   pnpm: "add",
   yarn: "add",
+  bun: "add",
 };
 
 export function generateCommitPublishMessage(


### PR DESCRIPTION
When using bun, the command would be undefined

![CleanShot 2024-07-28 at 07 26 58@2x](https://github.com/user-attachments/assets/296ca569-611e-4f8c-a04d-4d1ec4a81736)

This PR fixes that