### PR TITLE
fix: undefined is rendered as link if --no-template is passed

### DIFF
--- a/packages/backend/server/utils/markdown.ts
+++ b/packages/backend/server/utils/markdown.ts
@@ -94,8 +94,7 @@ function generateTemplatesStr(templates: Record<string, string>) {
   let str = templates["default"] ? `[Open in Stackblitz](${templates["default"]})` : '';
 
   if (entries.length && entries.length <= 2) {
-    str = str ? `${str} • ` : '';
-    str += entries.map(([k, v]) => `[${k}](${v})`).join(" • ");
+    str = [str, ...entries.map(([k, v]) => `[${k}](${v})`)].filter(Boolean).join(" • ");
   } else if (entries.length > 2) {
     str += createCollapsibleBlock(
       "<b>More templates</b>",

--- a/packages/backend/server/utils/markdown.ts
+++ b/packages/backend/server/utils/markdown.ts
@@ -91,7 +91,7 @@ ${templatesStr}
 
 function generateTemplatesStr(templates: Record<string, string>) {
   const entries = Object.entries(templates).filter(([k]) => k !== "default");
-  let str = `[Open in Stackblitz](${templates["default"]})`;
+  let str = templates["default"] ? `[Open in Stackblitz](${templates["default"]})` : '';
 
   if (entries.length && entries.length <= 2) {
     str += ` • ${entries.map(([k, v]) => `[${k}](${v})`).join(" • ")}`;

--- a/packages/backend/server/utils/markdown.ts
+++ b/packages/backend/server/utils/markdown.ts
@@ -94,7 +94,8 @@ function generateTemplatesStr(templates: Record<string, string>) {
   let str = templates["default"] ? `[Open in Stackblitz](${templates["default"]})` : '';
 
   if (entries.length && entries.length <= 2) {
-    str += ` • ${entries.map(([k, v]) => `[${k}](${v})`).join(" • ")}`;
+    str = str ? `${str} • ` : '';
+    str += entries.map(([k, v]) => `[${k}](${v})`).join(" • ");
   } else if (entries.length > 2) {
     str += createCollapsibleBlock(
       "<b>More templates</b>",


### PR DESCRIPTION
example - https://github.com/vuejs/vitepress/pull/4100#issuecomment-2270690009

there is also an extra bullet at end in that comment, but I guess it's because #166 isn't released yet?