### PR TITLE
feat: add `--only-templates` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ With `--comment=create`, each commit would generate a comment for itself, useful
 
 And `--comment=off` would turn off comments for maintainers who prefer minimal pull requests.
 
+For repositories with many packages, comments might get too long. In that case, you can use `--only-templates` to only show templates.
+
 pkg.pr.new uses `npm pack --json` under the hood, in case you face issues, you can also use the `--pnpm` flag so it starts using `pnpm pack`. This is not necessary in most cases.
 
 <img width="100%" src="https://github.com/stackblitz-labs/pkg.pr.new/assets/37929992/2fc03b94-ebae-4c47-a271-03a4ad5d2449" />

--- a/packages/backend/server/routes/publish.post.ts
+++ b/packages/backend/server/routes/publish.post.ts
@@ -19,8 +19,10 @@ export default eventHandler(async (event) => {
     "sb-comment": commentHeader,
     "sb-compact": compactHeader,
     "sb-package-manager": packageManagerHeader,
+    "sb-only-templates": onlyTemplatesHeader,
   } = getHeaders(event);
   const compact = compactHeader === "true";
+  const onlyTemplates = onlyTemplatesHeader === "true";
   const comment: Comment = (commentHeader ?? "update") as Comment;
   const packageManager: PackageManager =
     (packageManagerHeader as PackageManager) || "npm";
@@ -230,6 +232,7 @@ export default eventHandler(async (event) => {
               packagesWithoutPrefix,
               workflowData,
               compact,
+              onlyTemplates,
               checkRunUrl,
               packageManager,
               "ref",
@@ -249,6 +252,7 @@ export default eventHandler(async (event) => {
               packagesWithoutPrefix,
               workflowData,
               compact,
+              onlyTemplates,
               checkRunUrl,
               packageManager,
               comment === "update" ? "ref" : "sha",

--- a/packages/backend/server/utils/markdown.ts
+++ b/packages/backend/server/utils/markdown.ts
@@ -52,6 +52,7 @@ export function generatePullRequestPublishMessage(
   packages: string[],
   workflowData: WorkflowData,
   compact: boolean,
+  onlyTemplates: boolean,
   checkRunUrl: string,
   packageManager: PackageManager,
   base: "sha" | "ref",
@@ -79,6 +80,10 @@ ${packageManager} ${packageCommands[packageManager]} ${refUrl}
     .join("\n");
 
   const templatesStr = generateTemplatesStr(templates);
+
+  if(onlyTemplates) {
+    return templatesStr
+  }
 
   return `
 _commit: <a href="${checkRunUrl}"><code>${abbreviateCommitHash(workflowData.sha)}</code></a>_

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -64,6 +64,11 @@ const main = defineCommand({
             description: `"off" for no comments (silent mode). "create" for comment on each publish. "update" for one comment across the pull request with edits on each publish (default)`,
             default: "update",
           },
+          onlyTemplates: {
+            type: "boolean",
+            description: `generate only stackblitz templates`,
+            default: false,
+          },
         },
         run: async ({ args }) => {
           const paths = (args._.length ? args._ : ["."])
@@ -83,6 +88,7 @@ const main = defineCommand({
           const isCompact = !!args.compact;
           const isPnpm = !!args.pnpm;
           const isPeerDepsEnabled = !!args.peerDeps
+          const isOnlyTemplates = !!args.onlyTemplates
 
           const comment: Comment = args.comment as Comment;
 
@@ -299,6 +305,7 @@ const main = defineCommand({
               "sb-shasums": JSON.stringify(shasums),
               "sb-run-id": GITHUB_RUN_ID,
               "sb-package-manager": packageManager,
+              "sb-only-templates": `${isOnlyTemplates}`
             },
             body: formData,
           });


### PR DESCRIPTION
For instance, check this PR  in TanStack, https://github.com/TanStack/query/pull/7861

The problem is when repository has too many packages the amount of scroll on the PR page will increase, adding another detail to the pkg.pr.new links conditional with a flag like `--collapsed-links` will help resolve this case