### PR TITLE
docs: list Capawesome as project using pkg.pr.new

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These are some of the projects and companies using pkg.pr.new:
   <a href="https://valtio.pmnd.rs/"><img src="https://blog.stackblitz.com/posts/pkg-pr-new/valtio.svg" height="40"></a>
   <a href="https://github.com/nksaraf/vinxi"><img src="https://github.com/nksaraf/vinxi/raw/main/docs/public/logo.png" height="40"></a>
   <a href="https://github.com/scalar/scalar"><img src="https://github.com/scalar.png" height="40"></a>
+  <a href="https://github.com/capawesome-team/"><img src="https://avatars.githubusercontent.com/u/105555861?s=200&v=4" height="40"></a>
 </p>
 
 Feel free to add your project or company here!


### PR DESCRIPTION
Capawesome recently started using pkg.pr.new to continuously publish more than 30 packages. Thanks for this great project!

The idea to list Capawesome came from [Mohammad](https://x.com/aslemammadam/status/1825538789525397809?t=k9Xz6D9ZXLbWibNDwFk3nQ)! 🙌