### PR TITLE
refactor: use 25 less dependencies

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -14,7 +14,7 @@ import {
   extractOwnerAndRepo,
   extractRepository,
 } from "@pkg-pr-new/utils";
-import fg from "fast-glob";
+import { glob, globSync } from "tinyglobby";
 import ignore from "ignore";
 import "./environments";
 import pkg from "./package.json" with { type: "json" };
@@ -88,7 +88,7 @@ const main = defineCommand({
         },
         run: async ({ args }) => {
           const paths = (args._.length ? args._ : ["."])
-            .flatMap((p) => fg.sync(p, { onlyDirectories: true }))
+            .flatMap((p) => globSync([p], { expandDirectories: false, onlyDirectories: true }))
             .map((p) => path.resolve(p.trim()));
 
           const templates = (
@@ -96,7 +96,7 @@ const main = defineCommand({
               ? [args.template]
               : ([...(args.template || [])] as string[])
           )
-            .flatMap((p) => fg.sync(p, { onlyDirectories: true }))
+            .flatMap((p) => globSync([p], { expandDirectories: false, onlyDirectories: true }))
             .map((p) => path.resolve(p.trim()));
 
           const formData = new FormData();
@@ -231,11 +231,11 @@ const main = defineCommand({
               ig.add(gitignoreContent);
             }
 
-            const files = await fg(["**/*"], {
+            const files = await glob(["**/*"], {
               cwd: templateDir,
               dot: true,
               onlyFiles: true,
-              ignore: ['node_modules', '.git'], // always ignore node_modules and .git
+              ignore: ['**/node_modules', '.git'], // always ignore node_modules and .git
             });
 
             const filteredFiles = files.filter((file) => !ig.ignores(file));

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -6,7 +6,7 @@ import { createHash } from "node:crypto";
 import { hash } from "ohash";
 import fsSync from "fs";
 import fs from "fs/promises";
-import { detect } from "detect-package-manager";
+import { detect } from "package-manager-detector";
 import { getPackageManifest, type PackageManifest } from "query-registry";
 import type { Comment } from "@pkg-pr-new/utils";
 import {
@@ -348,7 +348,7 @@ const main = defineCommand({
               "sb-key": key,
               "sb-shasums": JSON.stringify(shasums),
               "sb-run-id": GITHUB_RUN_ID,
-              "sb-package-manager": packageManager,
+              "sb-package-manager": packageManager.agent ?? "npm",
               "sb-only-templates": `${isOnlyTemplates}`
             },
             body: formData,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,10 +23,10 @@
   "dependencies": {
     "@jsdevtools/ez-spawn": "^3.0.4",
     "@octokit/action": "^6.1.0",
-    "detect-package-manager": "^3.0.2",
     "fast-glob": "^3.3.2",
     "ignore": "^5.3.1",
     "isbinaryfile": "^5.0.2",
+    "package-manager-detector": "^0.1.2",
     "pkg-types": "^1.1.1",
     "query-registry": "^3.0.1"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,12 +23,12 @@
   "dependencies": {
     "@jsdevtools/ez-spawn": "^3.0.4",
     "@octokit/action": "^6.1.0",
-    "fast-glob": "^3.3.2",
     "ignore": "^5.3.1",
     "isbinaryfile": "^5.0.2",
     "package-manager-detector": "^0.1.2",
     "pkg-types": "^1.1.1",
-    "query-registry": "^3.0.1"
+    "query-registry": "^3.0.1",
+    "tinyglobby": "^0.2.2"
   },
   "devDependencies": {
     "@pkg-pr-new/utils": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,9 +110,6 @@ importers:
       '@octokit/action':
         specifier: ^6.1.0
         version: 6.1.0
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
       ignore:
         specifier: ^5.3.1
         version: 5.3.1
@@ -128,6 +125,9 @@ importers:
       query-registry:
         specifier: ^3.0.1
         version: 3.0.1
+      tinyglobby:
+        specifier: ^0.2.2
+        version: 0.2.2
     devDependencies:
       '@pkg-pr-new/utils':
         specifier: workspace:^
@@ -2105,6 +2105,14 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
+  fdir@6.2.0:
+    resolution: {integrity: sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3039,6 +3047,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
@@ -3522,6 +3534,10 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyglobby@0.2.2:
+    resolution: {integrity: sha512-mZ2sDMaySvi1PkTp4lTo1In2zjU+cY8OvZsfwrDrx3YGRbXPX1/cbPwCR9zkm3O/Fz9Jo0F1HNgIQ1b8BepqyQ==}
+    engines: {node: '>=12.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -5775,6 +5791,10 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
+  fdir@6.2.0(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
@@ -6801,6 +6821,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pirates@4.0.6: {}
 
   pkg-types@1.1.1:
@@ -7331,6 +7353,11 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  tinyglobby@0.2.2:
+    dependencies:
+      fdir: 6.2.0(picomatch@4.0.2)
+      picomatch: 4.0.2
 
   to-regex-range@5.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,9 +110,6 @@ importers:
       '@octokit/action':
         specifier: ^6.1.0
         version: 6.1.0
-      detect-package-manager:
-        specifier: ^3.0.2
-        version: 3.0.2
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
@@ -122,6 +119,9 @@ importers:
       isbinaryfile:
         specifier: ^5.0.2
         version: 5.0.2
+      package-manager-detector:
+        specifier: ^0.1.2
+        version: 0.1.2
       pkg-types:
         specifier: ^1.1.1
         version: 1.1.1
@@ -1781,10 +1781,6 @@ packages:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
     engines: {node: '>=8'}
 
-  detect-package-manager@3.0.2:
-    resolution: {integrity: sha512-8JFjJHutStYrfWwzfretQoyNGoZVW1Fsrp4JO9spa7h/fBfwgTMEIy4/LBzRDGsxwVPHU0q+T9YvwLDJoOApLQ==}
-    engines: {node: '>=12'}
-
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -2977,6 +2973,9 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  package-manager-detector@0.1.2:
+    resolution: {integrity: sha512-iePyefLTOm2gEzbaZKSW+eBMjg+UYsQvUKxmvGXAQ987K16efBg10MxIjZs08iyX+DY2/owKY9DIdu193kX33w==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -5257,10 +5256,6 @@ snapshots:
 
   detect-libc@2.0.3: {}
 
-  detect-package-manager@3.0.2:
-    dependencies:
-      execa: 5.1.1
-
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -6759,6 +6754,8 @@ snapshots:
       p-limit: 3.1.0
 
   p-try@2.2.0: {}
+
+  package-manager-detector@0.1.2: {}
 
   parent-module@1.0.1:
     dependencies:


### PR DESCRIPTION
pkg.pr.new looks really interesting and promising, but its dependency count is not optimal. this PR drops 25 dependencies by replacing `detect-package-manager` with [`package-manager-detector`](https://www.npmjs.com/package/package-manager-detector) and `fast-glob` with [`tinyglobby`](https://www.npmjs.com/package/tinyglobby)

there are more places to improve the dependency count that i didn't try to replace due to me not having enough experience replacing, like replacing `pkg-types` with something lighter, `@jsdevtools/ez-spawn` with `tinyexec` and it looks like `query-registry` too with normal `fetch()` calls. either way, thanks for pkg.pr.new!

```
Package size report
===================

Package info for "pkg-pr-new@0.0.20": 39 MB
  Released: 2024-08-06 18:40:40.604 +0000 UTC (2w ago)
  Downloads last week: 4,406 (86.56%)
  Estimated traffic last week: 171 GB
  Subdependencies: 87

Removed dependencies:
  - detect-package-manager@3.0.2: 226 kB (0.58%)
    Downloads last week: 44,090 (N/A% from 3.0.2)
    Downloads last week from "pkg-pr-new@0.0.20": 4,406 (N/A%)
    Traffic last week: N/A
    Traffic from "pkg-pr-new@0.0.20": 171 GB (N/A%)
    Subdependencies: 16 (18.39%)
  - fast-glob@3.3.2: 512 kB (1.32%)
    Downloads last week: 24,898,124 (N/A% from 3.3.2)
    Downloads last week from "pkg-pr-new@0.0.20": 4,406 (N/A%)
    Traffic last week: N/A
    Traffic from "pkg-pr-new@0.0.20": 171 GB (N/A%)
    Subdependencies: 17 (19.54%)

Added dependencies:
  + package-manager-detector@0.1.2: 24 kB (0.06%)
    Downloads last week: 238 (N/A% from 0.1.2)
    Estimated traffic last week: N/A
    Subdependencies: 0 (0%)
  + tinyglobby@0.2.2: 171 kB (0.44%)
    Downloads last week: 99,153 (N/A% from 0.2.2)
    Estimated traffic last week: N/A
    Subdependencies: 2 (2.29%)

Estimated new statistics:
  Package size: 39 MB → 38 MB (97.42%)
  Subdependencies: 87 → 62 (-25)
  Traffic with last week's downloads:
    For current version: 171 GB → 166 GB (4.4 GB saved)
    For all versions: 197 GB → 192 GB (5.1 GB saved)
```