### PR TITLE
chore: add rolldown to whitelist

### DIFF
--- a/.whitelist
+++ b/.whitelist
@@ -1,2 +1,3 @@
 stackblitz-labs/pkg.pr.new
 o1-labs/o1js
+rolldown/rolldown


### PR DESCRIPTION
Related to [rolldown/rolldown/#2090](https://github.com/rolldown/rolldown/pull/2090)

We attempted to use `pkg.pr.new`, but due to building with rust, the size exceeded expectations. Could we join the whitelist?