### PR TITLE
Add mermaid-js/mermaid to .whitelist

### DIFF
--- a/.whitelist
+++ b/.whitelist
@@ -2,3 +2,4 @@ stackblitz-labs/pkg.pr.new
 o1-labs/o1js
 rolldown/rolldown
 web-infra-dev/rspack
+mermaid-js/mermaid


### PR DESCRIPTION
Currently tried removing the .map files from mermaid to fit under the size limit. 
But that didn't work https://github.com/mermaid-js/mermaid/actions/runs/10906565961/job/30268106980?pr=5825