### PR TITLE
refactor: remove `.` pattern workaround

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -90,7 +90,7 @@ const main = defineCommand({
           },
         },
         run: async ({ args }) => {
-          const paths = args._.length
+          const paths = args._.length > 0
             ? await glob(args._, {
                 expandDirectories: false,
                 onlyDirectories: true,
@@ -98,27 +98,11 @@ const main = defineCommand({
               })
             : [process.cwd()];
 
-          if (args._.includes(".") || args._.includes("./")) {
-            paths.push(process.cwd());
-          }
-
-          const templatePatterns =
-            typeof args.template === "string"
-              ? [args.template]
-              : ([...(args.template || [])] as string[]);
-
-          const templates = await glob(templatePatterns, {
+          const templates = await glob(args.template ?? [], {
             expandDirectories: false,
             onlyDirectories: true,
             absolute: true,
           });
-
-          if (
-            templatePatterns.includes(".") ||
-            templatePatterns.includes("./")
-          ) {
-            templates.push(process.cwd());
-          }
 
           const formData = new FormData();
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "package-manager-detector": "^0.1.2",
     "pkg-types": "^1.1.1",
     "query-registry": "^3.0.1",
-    "tinyglobby": "^0.2.2"
+    "tinyglobby": "^0.2.7"
   },
   "devDependencies": {
     "@pkg-pr-new/utils": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       tinyglobby:
-        specifier: ^0.2.2
-        version: 0.2.2
+        specifier: ^0.2.7
+        version: 0.2.7
     devDependencies:
       '@pkg-pr-new/utils':
         specifier: workspace:^
@@ -2105,8 +2105,8 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
-  fdir@6.2.0:
-    resolution: {integrity: sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==}
+  fdir@6.4.0:
+    resolution: {integrity: sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -3535,8 +3535,8 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
-  tinyglobby@0.2.2:
-    resolution: {integrity: sha512-mZ2sDMaySvi1PkTp4lTo1In2zjU+cY8OvZsfwrDrx3YGRbXPX1/cbPwCR9zkm3O/Fz9Jo0F1HNgIQ1b8BepqyQ==}
+  tinyglobby@0.2.7:
+    resolution: {integrity: sha512-qFWYeNxBQxrOTRHvGjlRdBamy8JFqu6c0bwRru9leE+q8J72tLtlT0L3v+2T7fbLXN7FGzDNBhXkWiJqHUHD9g==}
     engines: {node: '>=12.0.0'}
 
   to-regex-range@5.0.1:
@@ -5791,7 +5791,7 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
-  fdir@6.2.0(picomatch@4.0.2):
+  fdir@6.4.0(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
 
@@ -7354,9 +7354,9 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  tinyglobby@0.2.2:
+  tinyglobby@0.2.7:
     dependencies:
-      fdir: 6.2.0(picomatch@4.0.2)
+      fdir: 6.4.0(picomatch@4.0.2)
       picomatch: 4.0.2
 
   to-regex-range@5.0.1:


### PR DESCRIPTION
tinyglobby 0.2.7 is out which removes the need for that workaround