### PR TITLE
fix: correct casing for GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ With pkg.pr.new, each of your commits and pull requests will trigger an instant 
 
 - 🚀 Instant Builds
 - 🍕 No Need for NPM Access
-- 🛠️ Github Workflows Friendly
+- 🛠️ GitHub Workflows Friendly
 - 📦️ No Configuration
 - 🔩 Single Command
 - ✉️ Pull Request Comments
@@ -84,7 +84,7 @@ Feel free to add your project or company here to join the pkg.pr.new family :)
 
 ## Setup
 
-First [install the Github Application](https://github.com/apps/pkg-pr-new).
+First [install the GitHub Application](https://github.com/apps/pkg-pr-new).
 
 > [!IMPORTANT]
 > Make sure it's installed on the repository before trying to publish a package.
@@ -102,7 +102,7 @@ npx pkg-pr-new publish './packages/A' './packages/B' # or `npx pkg-pr-new publis
 ```
 
 > [!IMPORTANT]
-> Make sure the pkg-pr-new command runs only once in a defined workflow (that's part of how it avoids spam)! So instead of multiple times running pkg-pr-new for each workspace package, the command should be run one time for all the desired packages using the pattern above. 
+> Make sure the pkg-pr-new command runs only once in a defined workflow (that's part of how it avoids spam)! So instead of multiple times running pkg-pr-new for each workspace package, the command should be run one time for all the desired packages using the pattern above.
 
 For templates (experimental):
 
@@ -121,7 +121,7 @@ For shorter urls, `--compact` can be useful:
 npx pkg-pr-new publish --compact './packages/A' './packages/B'
 ```
 
-> `--compact` requires your package to be a valid (published) package on npm with a specified `repository` field in the package.json! See [this](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository). pkg.pr.new is case sensitive, if the Github owner is `PuruVJ`, the package.json `repository` field should not have `puruvj`. 
+> `--compact` requires your package to be a valid (published) package on npm with a specified `repository` field in the package.json! See [this](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository). pkg.pr.new is case sensitive, if the GitHub owner is `PuruVJ`, the package.json `repository` field should not have `puruvj`.
 
 With `--compact`:
 

--- a/packages/backend/server/routes/multipart/create.post.ts
+++ b/packages/backend/server/routes/multipart/create.post.ts
@@ -16,7 +16,7 @@ export default eventHandler(async (event) => {
     throw createError({
       statusCode: 401,
       message:
-        "Try doing multipart uploads from a github workflow! Also make sure you install https://github.com/apps/pkg-pr-new Github app on the repo",
+        "Try doing multipart uploads from a github workflow! Also make sure you install https://github.com/apps/pkg-pr-new GitHub app on the repo",
     });
   }
   const workflowData = (await workflowsBucket.getItem(workflowKey))!;

--- a/packages/backend/server/routes/publish.post.ts
+++ b/packages/backend/server/routes/publish.post.ts
@@ -85,7 +85,7 @@ export default eventHandler(async (event) => {
     throw createError({
       statusCode: 401,
       message:
-        "Try publishing from a github workflow! Also make sure you install https://github.com/apps/pkg-pr-new Github app on the repo",
+        "Try publishing from a github workflow! Also make sure you install https://github.com/apps/pkg-pr-new GitHub app on the repo",
     });
   }
 

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -131,7 +131,7 @@ const main = defineCommand({
 
           if (!process.env.TEST && process.env.GITHUB_ACTIONS !== "true") {
             console.error(
-              "Continuous Releases are only available in Github Actions.",
+              "Continuous Releases are only available in GitHub Actions.",
             );
             process.exit(1);
           }


### PR DESCRIPTION
Very minor, but GitHub is spelled with a capital H ;) 