### PR TITLE
chore: add `tutorialkit` to list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ These are some of the projects and companies using pkg.pr.new:
    <a href="https://svelte.dev"><img src="https://svelte.dev/favicon.png" height="40" /></a>
    <a href="https://trpc.io"><img src="https://trpc.io/img/logo.svg" height="40" /></a>
    <a href="https://kysely.dev"><img src="https://kysely.dev/img/logo.svg" height="40" /></a>
+   <a href="https://tutorialkit.dev/"><img src="https://raw.githubusercontent.com/stackblitz/tutorialkit/refs/tags/1.3.0/extensions/vscode/resources/tutorialkit-icon.png" height="40" /></a>
 </p>
 
 Feel free to add your project or company here to join the pkg.pr.new family :)


### PR DESCRIPTION
Adds https://tutorialkit.dev/ to list of users.