### PR TITLE
Add studiocms to whitelist

### DIFF
--- a/.whitelist
+++ b/.whitelist
@@ -3,3 +3,4 @@ o1-labs/o1js
 rolldown/rolldown
 web-infra-dev/rspack
 mermaid-js/mermaid
+withstudiocms/studiocms


### PR DESCRIPTION
Greetings!

I'm from the @withstudiocms team, and we were hoping to be able to use `pkg.pr.new` for StudioCMS snapshots!

StudioCMS is a CMS that is built into an Astro Integration.

Currently getting the [following error](https://github.com/withstudiocms/studiocms/actions/runs/12010328848/job/33476935706?pr=385) and was directed to open a PR here to resolve!

Hopefully we can get access to the whitelist :smiley: as our CMS is broken out into multiple packages that seem to be causing a size issue :sweat_smile: 