### PR TITLE
fix: ensure template glob doesn't evaluate to `false`

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -104,7 +104,7 @@ const main = defineCommand({
                 })
               : [process.cwd()];
 
-          const templates = await glob(args.template ?? [], {
+          const templates = await glob(args.template || [], {
             expandDirectories: false,
             onlyDirectories: true,
             absolute: true,


### PR DESCRIPTION
fixes #302