### PR TITLE
fix: avoid pr hash collisions

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -2,8 +2,6 @@ name: pkg.pr.new stats
 
 on:
   push:
-    branches:
-      - main
 
 jobs:
   stats:

--- a/packages/backend/server/routes/publish.post.ts
+++ b/packages/backend/server/routes/publish.post.ts
@@ -254,46 +254,25 @@ export default eventHandler(async (event) => {
           },
         );
       } else {
-        try {
-          await installation.request(
-            "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
-            {
-              owner: workflowData.owner,
-              repo: workflowData.repo,
-              issue_number: Number(workflowData.ref),
-              body: generatePullRequestPublishMessage(
-                origin,
-                templatesHtmlMap,
-                packagesWithoutPrefix,
-                workflowData,
-                compact,
-                onlyTemplates,
-                checkRunUrl,
-                packageManager,
-                comment === "update" ? "ref" : "sha",
-              ),
-            },
-          );
-        } catch (error) {
-          throw createError({
-            statusCode: 500,
-            message: `Failed to create pull request comment. Details:
-            Error: ${error instanceof Error ? error.message : String(error)}
-            Context:
-            - Owner: ${workflowData.owner}
-            - Repo: ${workflowData.repo}
-            - Issue Number: ${Number(workflowData.ref)}
-            - Origin: ${origin}
-            - Templates: ${JSON.stringify(templatesHtmlMap)}
-            - Packages: ${packagesWithoutPrefix.join(', ')}
-            - Workflow Data: ${JSON.stringify(workflowData)}
-            - Compact: ${compact}
-            - Only Templates: ${onlyTemplates}
-            - Check Run URL: ${checkRunUrl}
-            - Package Manager: ${packageManager}
-            - Comment Type: ${comment === "update" ? "ref" : "sha"}`,
-          });
-        }
+        await installation.request(
+          "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+          {
+            owner: workflowData.owner,
+            repo: workflowData.repo,
+            issue_number: Number(workflowData.ref),
+            body: generatePullRequestPublishMessage(
+              origin,
+              templatesHtmlMap,
+              packagesWithoutPrefix,
+              workflowData,
+              compact,
+              onlyTemplates,
+              checkRunUrl,
+              packageManager,
+              comment === "update" ? "ref" : "sha",
+            ),
+          },
+        );
       }
     }
   }


### PR DESCRIPTION
the hash function of ohash has a short length and hitting hash collisions was kinda inevitable! 

so let's use proper keys from now on, for PRs, since they're long living, compared to workflow_run keys.

this would hopefully fix the element-plus issue we have. 