### PR TITLE
fix: generate valid dev private key

### DIFF
--- a/packages/backend/e2e.test.ts
+++ b/packages/backend/e2e.test.ts
@@ -15,8 +15,17 @@ beforeAll(async () => {
   const app = simulation({
     initialState: {
       users: [],
-      organizations: [{ login: "stackblitz-labs" }],
-      repositories: [{ owner: "stackblitz-labs", name: "temporary-test" }],
+      organizations: [
+        { login: "stackblitz-labs" },
+        { login: "tinylibs" },
+        { login: "stackblitz" },
+      ],
+      repositories: [
+        { owner: "stackblitz-labs", name: "temporary-test" },
+        { owner: "stackblitz-labs", name: "pkg.pr.new" },
+        { owner: "tinylibs", name: "tinybench" },
+        { owner: "stackblitz", name: "sdk" },
+      ],
       branches: [{ name: "main" }],
       blobs: [],
     },
@@ -156,7 +165,7 @@ describe.sequential.each([
     expect(installProcess.stdout).toContain(
       "playground-a installed successfully!",
     );
-  });
+  }, 10_000);
 
   it(`serves and installs playground-b for ${mode}`, async () => {
     const [owner, repo] = payload.repository.full_name.split("/");
@@ -186,7 +195,7 @@ describe.sequential.each([
     expect(installProcess.stdout).toContain(
       "playground-b installed successfully!",
     );
-  });
+  }, 10_000);
 });
 
 describe("URL redirects", () => {

--- a/packages/backend/script/generate-dev-vars.ts
+++ b/packages/backend/script/generate-dev-vars.ts
@@ -49,7 +49,7 @@ async function generateDevVars() {
         format: "pem",
       },
     });
-    updates.NITRO_PRIVATE_KEY = privateKey;
+    updates.NITRO_PRIVATE_KEY = `"${privateKey.split("\n").join("\\n")}"`;
   } else {
     updates.NITRO_PRIVATE_KEY = existingVars.NITRO_PRIVATE_KEY;
   }

--- a/packages/backend/server/routes/check.post.ts
+++ b/packages/backend/server/routes/check.post.ts
@@ -1,5 +1,4 @@
 export default eventHandler(async (event) => {
-  const { test } = useRuntimeConfig(event);
   const data = await readRawBody(event);
   const workflowsBucket = useWorkflowsBucket(event);
 
@@ -24,7 +23,7 @@ export default eventHandler(async (event) => {
     authenticated = true;
   } catch {}
 
-  if (!authenticated && !test) {
+  if (!authenticated) {
     throw createError({
       statusCode: 404,
       fatal: true,

--- a/packages/backend/server/routes/publish.post.ts
+++ b/packages/backend/server/routes/publish.post.ts
@@ -73,7 +73,7 @@ export default eventHandler(async (event) => {
     });
   }
 
-  const { appId, test } = useRuntimeConfig(event);
+  const { appId } = useRuntimeConfig(event);
   const cursorBucket = useCursorsBucket(event);
 
   if (!(await workflowsBucket.hasItem(key))) {
@@ -164,14 +164,6 @@ export default eventHandler(async (event) => {
   const urls = packagesWithoutPrefix.map((packageName) =>
     generatePublishUrl("sha", origin, packageName, workflowData, compact),
   );
-
-  // TODO: remove this once the simulator can handle the installation part (it is giving 404s now)
-  if (test) {
-    return {
-      ok: true,
-      urls,
-    };
-  }
 
   const installation = await useOctokitInstallation(
     event,


### PR DESCRIPTION
## Motivation

It appears that calls to the simulated GitHub endpoint were failing. However, the `octokit` instance was failing at creation due to an issue with the private key that was generated for testing purposes. Despite as such, the tests were still passing.

## Modifications

- Adjusted the private key to output as single line string. `octokit` could then make a valid instance.
- Removed the code paths which used `test` as dependency as they were not required.
- Added a few new org/repo combinations that would be used now that calls were being made to the GitHub simulator.
