### PR TITLE
chore: stable @simulacrum/github-api-simulator@0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@jsdevtools/ez-spawn": "^3.0.4",
     "@types/node": "^20.14.2",
-    "@simulacrum/github-api-simulator": "^0.5.3",
     "@vitejs/release-scripts": "^1.3.1",
     "cross-env": "^7.0.3",
     "esbuild": "^0.20.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,7 +26,7 @@
     "@octokit/webhooks": "^12.2.0",
     "@octokit/webhooks-types": "^7.4.0",
     "@pkg-pr-new/utils": "workspace:^",
-    "@simulacrum/github-api-simulator": "https://pkg.pr.new/thefrontside/simulacrum/@simulacrum/github-api-simulator@303",
+    "@simulacrum/github-api-simulator": "^0.5.4",
     "dotenv": "^16.4.5",
     "fast-jwt": "^4.0.2",
     "h3": "^1.11.1",
@@ -37,8 +37,5 @@
     "unstorage": "^1.10.2",
     "vitest": "2.1.8",
     "wrangler": "^3.57.1"
-  },
-  "dependencies": {
-    "@simulacrum/foundation-simulator": "^0.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@jsdevtools/ez-spawn':
         specifier: ^3.0.4
         version: 3.0.4
-      '@simulacrum/github-api-simulator':
-        specifier: ^0.5.3
-        version: 0.5.3(ajv@8.17.1)(picomatch@4.0.2)(react@18.3.1)
       '@types/node':
         specifier: ^20.14.2
         version: 20.14.2
@@ -76,10 +73,6 @@ importers:
         version: 1.1.0
 
   packages/backend:
-    dependencies:
-      '@simulacrum/foundation-simulator':
-        specifier: ^0.3.0
-        version: 0.3.0(ajv@8.17.1)(picomatch@4.0.2)(react@18.3.1)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20240512.0
@@ -118,8 +111,8 @@ importers:
         specifier: workspace:^
         version: link:../utils
       '@simulacrum/github-api-simulator':
-        specifier: https://pkg.pr.new/thefrontside/simulacrum/@simulacrum/github-api-simulator@303
-        version: https://pkg.pr.new/thefrontside/simulacrum/@simulacrum/github-api-simulator@303(ajv@8.17.1)(picomatch@4.0.2)(react@18.3.1)
+        specifier: ^0.5.4
+        version: 0.5.4(ajv@8.17.1)(picomatch@4.0.2)(react@18.3.1)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -1781,20 +1774,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@simulacrum/foundation-simulator@0.3.0':
-    resolution: {integrity: sha512-sQoX8HaiLHpUVQZTjflfp9NIJMx15daDfACooaSrx7Shed8LR+QcUIKF2DOokzbKJqRoWkAfvnFwwzSl5kVB5g==}
+  '@simulacrum/foundation-simulator@0.3.1':
+    resolution: {integrity: sha512-oO4SZqDgUogOIO5BEM/ffJq8hs2sA7g0sRiYk33PRwXhhWYAKw93YqOyWyAJ7KirVRuAE9O7+mI8ldBvWoT1GA==}
 
-  '@simulacrum/foundation-simulator@https://pkg.pr.new/thefrontside/simulacrum/@simulacrum/foundation-simulator@1a2894d8b878998b66cab75f0d61d9f351f23aeb':
-    resolution: {tarball: https://pkg.pr.new/thefrontside/simulacrum/@simulacrum/foundation-simulator@1a2894d8b878998b66cab75f0d61d9f351f23aeb}
-    version: 0.3.0
-
-  '@simulacrum/github-api-simulator@0.5.3':
-    resolution: {integrity: sha512-Bos7K/whTQ2ZAEqq07Ncw/uZwIrfPpJ8KAY5vYpG8KbLJO3DaNThWSyJwcCO8Bd8H0PRTc3M4gu9vZQbGyybRw==}
-    hasBin: true
-
-  '@simulacrum/github-api-simulator@https://pkg.pr.new/thefrontside/simulacrum/@simulacrum/github-api-simulator@303':
-    resolution: {tarball: https://pkg.pr.new/thefrontside/simulacrum/@simulacrum/github-api-simulator@303}
-    version: 0.5.3
+  '@simulacrum/github-api-simulator@0.5.4':
+    resolution: {integrity: sha512-XaqGCngPjFJ2+W8b0f//HE6YsvJVxsMtuzxfDxjkr4MA+OxHX1kyrQ9mlJjLSKWHPth/3SWX//ZzoApli8CR1w==}
     hasBin: true
 
   '@sindresorhus/merge-streams@2.3.0':
@@ -6554,7 +6538,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.30.1':
     optional: true
 
-  '@simulacrum/foundation-simulator@0.3.0(ajv@8.17.1)(picomatch@4.0.2)(react@18.3.1)':
+  '@simulacrum/foundation-simulator@0.3.1(ajv@8.17.1)(picomatch@4.0.2)(react@18.3.1)':
     dependencies:
       ajv-formats: 3.0.1(ajv@8.17.1)
       cors: 2.8.5
@@ -6576,50 +6560,10 @@ snapshots:
       - redux
       - supports-color
 
-  '@simulacrum/foundation-simulator@https://pkg.pr.new/thefrontside/simulacrum/@simulacrum/foundation-simulator@1a2894d8b878998b66cab75f0d61d9f351f23aeb(ajv@8.17.1)(picomatch@4.0.2)(react@18.3.1)':
-    dependencies:
-      ajv-formats: 3.0.1(ajv@8.17.1)
-      cors: 2.8.5
-      express: 4.21.2
-      fdir: 6.4.0(picomatch@4.0.2)
-      http-proxy-middleware: 3.0.3
-      lodash: 4.17.21
-      openapi-backend: 5.11.1
-      openapi-merge: 1.3.3
-      react-dom: 18.3.1(react@18.3.1)
-      starfx: 0.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - ajv
-      - picomatch
-      - react
-      - react-native
-      - redux
-      - supports-color
-
-  '@simulacrum/github-api-simulator@0.5.3(ajv@8.17.1)(picomatch@4.0.2)(react@18.3.1)':
+  '@simulacrum/github-api-simulator@0.5.4(ajv@8.17.1)(picomatch@4.0.2)(react@18.3.1)':
     dependencies:
       '@faker-js/faker': 9.4.0
-      '@simulacrum/foundation-simulator': 0.3.0(ajv@8.17.1)(picomatch@4.0.2)(react@18.3.1)
-      assert-ts: 0.3.4
-      graphql: 16.10.0
-      graphql-yoga: 5.10.11(graphql@16.10.0)
-      zod: 3.24.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - ajv
-      - picomatch
-      - react
-      - react-native
-      - redux
-      - supports-color
-
-  '@simulacrum/github-api-simulator@https://pkg.pr.new/thefrontside/simulacrum/@simulacrum/github-api-simulator@303(ajv@8.17.1)(picomatch@4.0.2)(react@18.3.1)':
-    dependencies:
-      '@faker-js/faker': 9.4.0
-      '@simulacrum/foundation-simulator': https://pkg.pr.new/thefrontside/simulacrum/@simulacrum/foundation-simulator@1a2894d8b878998b66cab75f0d61d9f351f23aeb(ajv@8.17.1)(picomatch@4.0.2)(react@18.3.1)
+      '@simulacrum/foundation-simulator': 0.3.1(ajv@8.17.1)(picomatch@4.0.2)(react@18.3.1)
       assert-ts: 0.3.4
       graphql: 16.10.0
       graphql-yoga: 5.10.11(graphql@16.10.0)
@@ -7785,10 +7729,10 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0))(eslint-plugin-n@16.6.2(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint@8.57.0):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.29.1)(eslint-plugin-n@16.6.2(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-n: 16.6.2(eslint@8.57.0)
       eslint-plugin-promise: 6.1.1(eslint@8.57.0)
 
@@ -7798,9 +7742,9 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-config-prettier: 8.10.0(eslint@8.57.0)
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0))(eslint-plugin-n@16.6.2(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.29.1)(eslint-plugin-n@16.6.2(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-n: 16.6.2(eslint@8.57.0)
       eslint-plugin-node: 11.1.0(eslint@8.57.0)
       eslint-plugin-promise: 6.1.1(eslint@8.57.0)
@@ -7819,13 +7763,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -7836,14 +7780,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7860,7 +7804,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -7870,7 +7814,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Motivation

We confirmed the simulator from the preview pkg 💪 . We released the stable version with the same, simply bumping over to it.
