### PR TITLE
feat: allow for showing `npx` instead of `npm install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ Without `--compact`:
 npm i https://pkg.pr.new/tinylibs/tinybench/tinybench@a832a55
 ```
 
+For CLI applications you might want to show `npx` instead of `npm i` for the preview command. This can be accomplished with the `--bin` flag:
+
+```sh
+npx pkg-pr-new publish --bin 
+```
+
+With `--bin`:
+```sh
+npx https://pkg.pr.new/pkg-pr-new@a832a55
+```
+
+Without `--bin`:
+```sh
+npm i https://pkg.pr.new/pkg-pr-new@a832a55
+```
+
 You can control publishing comments with `--comment`:
 
 ```sh

--- a/packages/backend/server/routes/publish.post.ts
+++ b/packages/backend/server/routes/publish.post.ts
@@ -14,12 +14,14 @@ export default eventHandler(async (event) => {
     "sb-shasums": shasumsHeader,
     "sb-comment": commentHeader,
     "sb-compact": compactHeader,
+    "sb-bin": binHeader,
     "sb-package-manager": packageManagerHeader,
     "sb-only-templates": onlyTemplatesHeader,
   } = getHeaders(event);
   const compact = compactHeader === "true";
   const onlyTemplates = onlyTemplatesHeader === "true";
   const comment: Comment = (commentHeader ?? "update") as Comment;
+  const bin = binHeader === "true";
   const packageManager: PackageManager =
     (packageManagerHeader as PackageManager) || "npm";
 
@@ -205,6 +207,7 @@ export default eventHandler(async (event) => {
           workflowData,
           compact,
           packageManager,
+          bin
         ),
       },
       conclusion: "success",
@@ -261,6 +264,7 @@ export default eventHandler(async (event) => {
                 checkRunUrl,
                 packageManager,
                 "ref",
+                bin
               ),
             },
           );
@@ -281,6 +285,7 @@ export default eventHandler(async (event) => {
                 checkRunUrl,
                 packageManager,
                 comment === "update" ? "ref" : "sha",
+                bin
               ),
             },
           );

--- a/packages/backend/server/utils/markdown.ts
+++ b/packages/backend/server/utils/markdown.ts
@@ -1,11 +1,18 @@
 import { abbreviateCommitHash, PackageManager } from "@pkg-pr-new/utils";
 import { WorkflowData } from "../types";
 
-const packageCommands: Record<PackageManager, string> = {
-  npm: "i",
-  pnpm: "add",
-  yarn: "add",
-  bun: "add",
+const installCommands: Record<PackageManager, string> = {
+  npm: "npm i",
+  pnpm: "pnpm add",
+  yarn: "yarn add",
+  bun: "bun add",
+};
+
+const binCommands: Record<PackageManager, string> = {
+  npm: "npx",
+  pnpm: "pnpm dlx",
+  yarn: "npx",
+  bun: "bunx",
 };
 
 export function generateCommitPublishMessage(
@@ -15,6 +22,7 @@ export function generateCommitPublishMessage(
   workflowData: WorkflowData,
   compact: boolean,
   packageManager: PackageManager,
+  bin: boolean,
 ) {
   const isMoreThanFour = packages.length > 4;
   const shaMessages = packages
@@ -33,7 +41,7 @@ export function generateCommitPublishMessage(
 
       return `
 \`\`\`
-${packageManager} ${packageCommands[packageManager]} ${shaUrl}
+${bin ? binCommands[packageManager] : installCommands[packageManager]} ${shaUrl}
 \`\`\`
       `;
     })
@@ -63,6 +71,7 @@ export function generatePullRequestPublishMessage(
   checkRunUrl: string,
   packageManager: PackageManager,
   base: "sha" | "ref",
+  bin: boolean,
 ) {
   const isMoreThanFour = packages.length > 4;
   const refMessages = packages
@@ -81,7 +90,7 @@ export function generatePullRequestPublishMessage(
 
       return `
 \`\`\`
-${packageManager} ${packageCommands[packageManager]} ${refUrl}
+${bin ? binCommands[packageManager] : installCommands[packageManager]} ${refUrl}
 \`\`\`
 `;
     })

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -95,6 +95,11 @@ const main = defineCommand({
             enum: ["npm", "bun", "pnpm", "yarn"],
             default: "npm",
           },
+          bin: {
+            type: "boolean",
+            description:
+              "Set to true if your package is a binary application and you would like to show an execute command instead of an install command.",
+          },
         },
         run: async ({ args }) => {
           const paths =
@@ -126,6 +131,7 @@ const main = defineCommand({
           const isPeerDepsEnabled = !!args.peerDeps;
           const isOnlyTemplates = !!args["only-templates"];
 
+          const isBinaryApplication = !!args.binaryApplication;
           const comment: Comment = args.comment as Comment;
           const selectedPackageManager = args.packageManager as
             | "npm"
@@ -485,6 +491,7 @@ const main = defineCommand({
               "sb-key": key,
               "sb-shasums": JSON.stringify(shasums),
               "sb-run-id": GITHUB_RUN_ID,
+              "sb-bin": `${isBinaryApplication}`,
               "sb-package-manager": selectedPackageManager,
               "sb-only-templates": `${isOnlyTemplates}`,
             },


### PR DESCRIPTION
Fixes #263 

Adds a `--bin` flag to allow for displaying an execute command instead of an install command i.e. instead of `npm i` it would be `npx`

Forgive me I am not exactly sure how to test my changes so let me know what I can do!