### PR TITLE
fix: update markdown template formatting for better readability

### DIFF
--- a/packages/app/server/utils/markdown.ts
+++ b/packages/app/server/utils/markdown.ts
@@ -120,9 +120,9 @@ function generateTemplatesStr(templates: Record<string, string>) {
       : "";
 
   if (entries.length > 0 && entries.length <= 2) {
-    str = [str, ...entries.map(([k, v]) => `[${k}](${v})`)]
+    str = [str, ...entries.map(([k, v]) => `- [${k}](${v})`)]
       .filter(Boolean)
-      .join(" • ");
+      .join("\n");
   } else if (entries.length > 2) {
     str += createCollapsibleBlock(
       "<b>More templates</b>",


### PR DESCRIPTION
I think we should use md in github comments. At least when the number of comments is equal to 2, it should be two lines instead of just one line.

- `entries.length = 1`
  - before
 
![image](https://github.com/user-attachments/assets/e4699258-5f4c-48f0-b429-d4e0d637d5b7)

  - after:

![image](https://github.com/user-attachments/assets/7361dca1-63db-4b38-a4f9-d6912132e524)

---

- `entries.length = 2`
  - before
 
![image](https://github.com/user-attachments/assets/8d54cf0c-62cf-436e-9940-9228154d69f8)

  - after:

![image](https://github.com/user-attachments/assets/821f7468-5af6-4f2e-94a1-d05a3b87d34c)
