### PR TITLE
chore: add ReScript to the `.whitelist`

### DIFF
--- a/.whitelist
+++ b/.whitelist
@@ -7,3 +7,4 @@ withstudiocms/studiocms
 QwikDev/qwik
 biomejs/biome
 sanity-io/sanity
+rescript-lang/rescript


### PR DESCRIPTION
Hi there, thank you for making a fantastic tool!

[ReScript](https://github.com/rescript-lang/rescript) team is trying pkg.pr.new from https://github.com/rescript-lang/rescript/pull/7412 and is facing the 20 MB limit.

Our npm packages are ~70 MiB, including `rescript` and per-platform binary packages.