### PR TITLE
feat(cli): append some context to `GITHUB_OUTPUT`

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ After `pkg-pr-new publish` runs successfully, some outputs are available.
 
 - `sha`: The short SHA used. (E.g. `a832a55`)
 - `urls`: Space-separated URLs of published packages.
+- `packages`: Space-separated, Yarn-compatible package locators of published packages.
 
 This is useful for using published packages in other subsequent jobs immediately after publishing. (E.g. E2E tests)
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,68 @@ on:
 
 As noted in [#140](https://github.com/stackblitz-labs/pkg.pr.new/issues/140), workflows run on tags too, that's not an issue at all, but in case users would like to avoid duplicate publishes.
 
+#### Run E2E test using outputs
+
+After `pkg-pr-new publish` runs successfully, some outputs are available.
+
+- `tag`: The short SHA used. (e.g. `a832a55`)
+- `packages`: Space-separated URLs of published packages.
+
+This is useful for using published packages in other subsequent jobs immediately after publishing. (E.g. E2E tests)
+
+```yml
+name: Publish and Test Packages
+on: [push, pull_request]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.publish.outputs.tag }}
+      packages: ${{ steps.publish.outputs.packages }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - id: publish
+        run: pnpm dlx pkg-pr-new publish
+
+  e2e-test:
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: user/my-package-e2e
+
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install published package
+        run: pnpm add ${{ needs.publish.outputs.packages }}
+
+      - name: Run e2e test cases
+        run: # ...
+```
+
 ## Custom GitHub Messages and Comments
 
 For advanced use cases where you want more control over the messages posted by pkg.pr.new, you can use the `--json` option in combination with `--comment=off`. This allows you to generate metadata about the publish operation without creating a default comment, which you can then use to create custom comments via the GitHub Actions API.

--- a/README.md
+++ b/README.md
@@ -307,8 +307,8 @@ As noted in [#140](https://github.com/stackblitz-labs/pkg.pr.new/issues/140), wo
 
 After `pkg-pr-new publish` runs successfully, some outputs are available.
 
-- `tag`: The short SHA used. (e.g. `a832a55`)
-- `packages`: Space-separated URLs of published packages.
+- `sha`: The short SHA used. (E.g. `a832a55`)
+- `urls`: Space-separated URLs of published packages.
 
 This is useful for using published packages in other subsequent jobs immediately after publishing. (E.g. E2E tests)
 
@@ -320,8 +320,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.publish.outputs.tag }}
-      packages: ${{ steps.publish.outputs.packages }}
+      sha: ${{ steps.publish.outputs.sha }}
+      urls: ${{ steps.publish.outputs.urls }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -359,7 +359,7 @@ jobs:
         run: pnpm install
 
       - name: Install published package
-        run: pnpm add ${{ needs.publish.outputs.packages }}
+        run: pnpm add ${{ needs.publish.outputs.urls }}
 
       - name: Run e2e test cases
         run: # ...

--- a/packages/cli/environments.ts
+++ b/packages/cli/environments.ts
@@ -30,6 +30,8 @@ declare global {
       GITHUB_JOB: string;
       // A unique number for each attempt of a particular workflow run in a repository. This number begins at 1 for the workflow run's first attempt, and increments with each re-run. For example, 3.
       GITHUB_RUN_ATTEMPT: string;
+      // A file to set action outputs
+      GITHUB_OUTPUT: string;
     }
   }
 }

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -561,6 +561,11 @@ const main = defineCommand({
             `urls=${outputMetadata.packages.map((pkg) => pkg.url).join(" ")}\n`,
             "utf8",
           );
+          await fs.appendFile(
+            GITHUB_OUTPUT,
+            `packages=${outputMetadata.packages.map((pkg) => `${pkg.name}@${pkg.url}`).join(" ")}\n`,
+            "utf8",
+          );
         },
       };
     },

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -227,8 +227,6 @@ const main = defineCommand({
             if (isCompact) {
               await verifyCompactMode(pJson.name);
             }
-
-            const formattedSha = isCompact ? abbreviateCommitHash(sha) : sha;
             const longDepUrl = new URL(
               `/${owner}/${repo}/${pJson.name}@${formattedSha}`,
               apiUrl,

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -555,10 +555,10 @@ const main = defineCommand({
             console.warn(`metadata written to ${jsonFilePath}`);
           }
 
-          await fs.appendFile(GITHUB_OUTPUT, `tag=${formattedSha}\n`, "utf8");
+          await fs.appendFile(GITHUB_OUTPUT, `sha=${formattedSha}\n`, "utf8");
           await fs.appendFile(
             GITHUB_OUTPUT,
-            `packages=${outputMetadata.packages.map((pkg) => pkg.url).join(" ")}\n`,
+            `urls=${outputMetadata.packages.map((pkg) => pkg.url).join(" ")}\n`,
             "utf8",
           );
         },

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -110,10 +110,10 @@ const main = defineCommand({
           const paths =
             args._.length > 0
               ? await glob(args._, {
-                  expandDirectories: false,
-                  onlyDirectories: true,
-                  absolute: true,
-                })
+                expandDirectories: false,
+                onlyDirectories: true,
+                absolute: true,
+              })
               : [process.cwd()];
 
           const templates = await glob(args.template || [], {
@@ -164,6 +164,7 @@ const main = defineCommand({
             GITHUB_RUN_ID,
             GITHUB_RUN_ATTEMPT,
             GITHUB_ACTOR_ID,
+            GITHUB_OUTPUT,
           } = process.env;
 
           const [owner, repo] = GITHUB_REPOSITORY.split("/");
@@ -193,6 +194,7 @@ const main = defineCommand({
           }
 
           const { sha } = await checkResponse.json();
+          const formattedSha = isCompact ? abbreviateCommitHash(sha) : sha;
 
           const deps: Map<string, string> = new Map(); // pkg.pr.new versions of the package
           const realDeps: Map<string, string> | null = isPeerDepsEnabled
@@ -552,6 +554,13 @@ const main = defineCommand({
             await fs.writeFile(jsonFilePath, output);
             console.warn(`metadata written to ${jsonFilePath}`);
           }
+
+          await fs.appendFile(GITHUB_OUTPUT, `tag=${formattedSha}\n`, "utf8");
+          await fs.appendFile(
+            GITHUB_OUTPUT,
+            `packages=${outputMetadata.packages.map((pkg) => pkg.url).join(" ")}\n`,
+            "utf8",
+          );
         },
       };
     },

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -110,10 +110,10 @@ const main = defineCommand({
           const paths =
             args._.length > 0
               ? await glob(args._, {
-                expandDirectories: false,
-                onlyDirectories: true,
-                absolute: true,
-              })
+                  expandDirectories: false,
+                  onlyDirectories: true,
+                  absolute: true,
+                })
               : [process.cwd()];
 
           const templates = await glob(args.template || [], {


### PR DESCRIPTION
Added some useful context.

- `*.outputs.sha`: determined package tag (the short sha)
- `*.outputs.urls`: space-separated package URLs, can be passed `npm i` or `pnpm add` directly.
- `*.outputs.packages`: space-separated package locators, can be passed `yarn add` directly.

Resolves #363 