### PR TITLE
fix: specify package name in descriptor for yarn

### DIFF
--- a/packages/app/server/utils/markdown.ts
+++ b/packages/app/server/utils/markdown.ts
@@ -39,9 +39,11 @@ export function generateCommitPublishMessage(
         shaUrl = shaUrl + ".tgz";
       }
 
+      const packageSpec = `${packageManager === "yarn" ? `${packageName}@` : ""}${shaUrl}`;
+
       return `
 \`\`\`
-${bin ? binCommands[packageManager] : installCommands[packageManager]} ${shaUrl}
+${bin ? binCommands[packageManager] : installCommands[packageManager]} ${packageSpec}
 \`\`\`
       `;
     })

--- a/packages/app/server/utils/markdown.ts
+++ b/packages/app/server/utils/markdown.ts
@@ -39,11 +39,11 @@ export function generateCommitPublishMessage(
         shaUrl = shaUrl + ".tgz";
       }
 
-      const packageSpec = `${packageManager === "yarn" ? `${packageName}@` : ""}${shaUrl}`;
+      const descriptor = `${packageManager === "yarn" ? `${packageName}@` : ""}${shaUrl}`;
 
       return `
 \`\`\`
-${bin ? binCommands[packageManager] : installCommands[packageManager]} ${packageSpec}
+${bin ? binCommands[packageManager] : installCommands[packageManager]} ${descriptor}
 \`\`\`
       `;
     })


### PR DESCRIPTION
https://github.com/yarnpkg/berry/blob/666aa3ac20de796e0159f9d4aa029715ccf5ec55/packages/plugin-essentials/sources/commands/add.ts#L184

Yarn now requires package names to be explicitly specified in descriptor when using `add` command.