### PR TITLE
fix: Correctly parse `--yarn`

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -69,6 +69,10 @@ const main = defineCommand({
             type: "boolean",
             description: "use `pnpm pack` instead of `npm pack --json`",
           },
+          yarn: {
+            type: "boolean",
+            description: "use `yarn pack` instead of `npm pack --json`",
+          },
           template: {
             type: "string",
             description:


### PR DESCRIPTION
`--yarn` was not parsed correctly, causing the following `'./packages/*'` to be ignored.
Ref: https://github.com/stackblitz-labs/pkg.pr.new/issues/321