### PR TITLE
Add garden-co/jazz to the whitelist

### DIFF
--- a/.whitelist
+++ b/.whitelist
@@ -9,3 +9,4 @@ biomejs/biome
 sanity-io/sanity
 rescript-lang/rescript
 tanstack/router
+garden-co/jazz


### PR DESCRIPTION
Greetings!
I am from [@garden-co](https://github.com/garden-co) team, I would like to add [jazz-tools](https://github.com/garden-co/jazz) to the size whitelist so we can use pkg.pr.new previews.

Our React Native Core package exceed 20 MB due to required native binaries, and this will enable preview builds over that limit.