### PR TITLE
fix(cli): update publish success warn info

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -13,6 +13,7 @@ import {
   abbreviateCommitHash,
   extractOwnerAndRepo,
   extractRepository,
+  installCommands,
 } from "@pkg-pr-new/utils";
 import { glob } from "tinyglobby";
 import ignore from "ignore";
@@ -544,7 +545,7 @@ const main = defineCommand({
               return `${packageName}:
 - sha: ${shasums[packageName]}
 - publint: ${publintUrl}
-- npm: npm i ${url}`;
+- ${packMethod}: ${installCommands[packMethod]} ${url}`;
             })
             .join("\n\n");
 

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -37,6 +37,13 @@ export function isPullRequest(ref: string) {
 export type Comment = "off" | "create" | "update";
 export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
 
+export const installCommands: Record<PackageManager, string> = {
+  npm: "npm i",
+  pnpm: "pnpm add",
+  yarn: "yarn add",
+  bun: "bun add",
+};
+
 const whitelist =
   "https://raw.githubusercontent.com/stackblitz-labs/pkg.pr.new/main/.whitelist";
 


### PR DESCRIPTION
The installation command and the specified packageManager are consistent in the output information.