### PR TITLE
Add wasp-lang to the whitelist

### DIFF
--- a/.whitelist
+++ b/.whitelist
@@ -13,3 +13,4 @@ garden-co/jazz
 six-group/six-webcomponents
 TDesignOteam/tdesign-web-components
 Tencent/tdesign-vue-next
+wasp-lang/wasp


### PR DESCRIPTION
Hi!
At https://github.com/wasp-lang/wasp and https://github.com/wasp-lang/open-saas we're starting to implement distribution for our compiler through npm packages. Access to pkg.pr.new would be helpful in testing new features and allowing contributors to easily test out nightly versions.
Thanks!