### PR TITLE
Add dxos to the whitelist

### DIFF
--- a/.whitelist
+++ b/.whitelist
@@ -14,3 +14,4 @@ six-group/six-webcomponents
 TDesignOteam/tdesign-web-components
 Tencent/tdesign-vue-next
 wasp-lang/wasp
+dxos/dxos


### PR DESCRIPTION
Happy holidays! At DXOS we were looking for better ways of distributing unreleased code and found pkg.pr.new, it looks really useful. I was trying to test it out but ran into the limit when publishing some of our packages.