### PR TITLE
chore: update eslint ignores

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default [
       ".nuxt/**",
       "packages/*/dist/**",
       "packages/app/.nuxt/**",
+      "packages/app/.wrangler/**",
       "packages/cli/dist/**",
     ],
   },


### PR DESCRIPTION
Sometimes a .wrangler folder is generated, and running lint will result in many errors.