### PR TITLE
Add clerk/javascript to whitelist

### DIFF
--- a/.whitelist
+++ b/.whitelist
@@ -16,3 +16,4 @@ Tencent/tdesign-vue-next
 wasp-lang/wasp
 dxos/dxos
 CopilotKit/CopilotKit
+clerk/javascript


### PR DESCRIPTION
## Summary

Adding `clerk/javascript` to the whitelist to allow publishing preview packages that exceed the 20MB limit.

## Context

The [clerk/javascript](https://github.com/clerk/javascript) monorepo contains the official Clerk SDKs for JavaScript/TypeScript. The combined package sizes exceed the 20MB limit:

| Package | Size |
|---------|------|
| `@clerk/ui` | ~60 MB |
| `@clerk/react` | ~44 MB |
| `@clerk/chrome-extension` | ~39 MB |
| `@clerk/localizations` | ~36 MB |
| `@clerk/shared` | ~12 MB |
| `@clerk/clerk-js` | ~12 MB |

Current CI failures show:
```
publishing failed: Max payload limit is 20mb! Feel free to apply for the whitelist
```

Thank you for considering this request!