### PR TITLE
chore: whitelist React Email

### DIFF
--- a/.whitelist
+++ b/.whitelist
@@ -17,3 +17,4 @@ wasp-lang/wasp
 dxos/dxos
 CopilotKit/CopilotKit
 clerk/javascript
+resend/react-email


### PR DESCRIPTION
Just adds `resend/react-email` to the whitelist. The biggest package we
publish, (and test with `pkg.pr.new`), is `@react-email/preview-server` which is
the UI, equivalent to what's in https://demo.react.email. We're doing some
explorations to make things stabler, and it also increases the
size of the package.

We love pkg.pr.new, btw :)

https://github.com/resend/react-email