### PR TITLE
fix(api/repo/commits): change the package name delimiter from colon to slash

### DIFF
--- a/packages/app/server/api/repo/commits.get.ts
+++ b/packages/app/server/api/repo/commits.get.ts
@@ -184,7 +184,7 @@ export default defineEventHandler(async (event) => {
         if (!sha || packageNameParts.length === 0) {
           continue;
         }
-        const packageName = packageNameParts.join(":");
+        const packageName = packageNameParts.join("/");
         const uploadedAt = new Date(object.uploaded).getTime();
 
         const row = rows.get(sha);


### PR DESCRIPTION
<img width="5390" height="1796" alt="image" src="https://github.com/user-attachments/assets/70c3947e-546c-4d55-9ada-5d41d00ef136" />

error:      npm i https://pkg.pr.new/vitejs/vite/@vitejs:plugin-legacy@5c921ca
correct:  npm i https://pkg.pr.new/vitejs/vite/@vitejs/plugin-legacy@5c921ca