### PR TITLE
fix: keep scoped package slash in generated install URLs

### DIFF
--- a/packages/app/server/api/repo/commits.get.ts
+++ b/packages/app/server/api/repo/commits.get.ts
@@ -184,7 +184,7 @@ export default defineEventHandler(async (event) => {
         if (!sha || packageNameParts.length === 0) {
           continue;
         }
-        const packageName = packageNameParts.join(":");
+        const packageName = packageNameParts.join(":").replaceAll(":", "/");
         const uploadedAt = new Date(object.uploaded).getTime();
 
         const row = rows.get(sha);


### PR DESCRIPTION
## Summary
Fixes the scoped package install URL formatting issue reported in #477.

When release package names are reconstructed from storage keys, scoped packages were kept in normalized `@scope:pkg` form. This propagated to generated install commands and produced invalid URLs.

This change converts normalized separators back to npm package form (`/`) before rendering release text, so generated install commands use `@scope/pkg` correctly.

## Verification
- Updated package-name reconstruction logic in `packages/app/server/api/repo/commits.get.ts`.