### PR TITLE
fix: initial comment with `--commentWithSha`

### DIFF
--- a/packages/app/server/routes/publish.post.ts
+++ b/packages/app/server/routes/publish.post.ts
@@ -293,6 +293,20 @@ export default eventHandler(async (event) => {
           },
         );
 
+        const body = generatePullRequestPublishMessage(
+          origin,
+          templatesHtmlMap,
+          packagesWithoutPrefix,
+          workflowData,
+          compact,
+          onlyTemplates,
+          checkRunUrl,
+          packageManager,
+          commentWithSha || comment !== "update" ? "sha" : "ref",
+          bin,
+          commentWithDev,
+        );
+
         try {
           if (comment === "update" && prevComment!) {
             await installation.request(
@@ -301,19 +315,7 @@ export default eventHandler(async (event) => {
                 owner: workflowData.owner,
                 repo: workflowData.repo,
                 comment_id: prevComment.id,
-                body: generatePullRequestPublishMessage(
-                  origin,
-                  templatesHtmlMap,
-                  packagesWithoutPrefix,
-                  workflowData,
-                  compact,
-                  onlyTemplates,
-                  checkRunUrl,
-                  packageManager,
-                  commentWithSha ? "sha" : "ref",
-                  bin,
-                  commentWithDev,
-                ),
+                body,
               },
             );
           } else {
@@ -323,19 +325,7 @@ export default eventHandler(async (event) => {
                 owner: workflowData.owner,
                 repo: workflowData.repo,
                 issue_number: Number(workflowData.ref),
-                body: generatePullRequestPublishMessage(
-                  origin,
-                  templatesHtmlMap,
-                  packagesWithoutPrefix,
-                  workflowData,
-                  compact,
-                  onlyTemplates,
-                  checkRunUrl,
-                  packageManager,
-                  comment === "update" ? "ref" : "sha",
-                  bin,
-                  commentWithDev,
-                ),
+                body,
               },
             );
           }


### PR DESCRIPTION
When using `--commentWithSha`, the ref is still used for the initial comment. The SHA is only used for subsequent updates to the comment using `PATCH`.

While this *could* be intentional, I don't think it is. The documentation seems to imply that it should use the SHA. I also checked the discussion on the initial PR that implemented this feature, #432. I don't see anything there that suggests the initial `POST` should be handled differently.

CC @btea

---

There are two branches (`if`/`else`) that call `generatePullRequestPublishMessage` with essentially the same arguments, so I've moved that up a bit to avoid the duplication. I think that duplication is what led to this problem being introduced in the first place.

I've then tweaked the logic for passing `sha` or `ref`, which was the only difference between those two branches.

---

I wasn't sure how to run these changes locally. I assume there's some way to run the code without deploying it to the live application, but I couldn't figure it out. While I think my change is correct, apologies in advance for opening a PR with untested code.