### PR TITLE
fix: skip name checks for private packages

### DIFF
--- a/packages/app/e2e.test.ts
+++ b/packages/app/e2e.test.ts
@@ -153,6 +153,9 @@ describe.sequential.each([
     expect(process.stderr).toContain("pkg-pr-new:");
     expect(process.stderr).toContain("playground-a:");
     expect(process.stderr).toContain("playground-b:");
+    expect(process.stderr).toContain(
+      "private-playground/ because the package is private",
+    );
   }, 20_000);
 
   it(`serves and installs playground-a for ${mode}`, async () => {

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -274,15 +274,12 @@ const main = defineCommand({
             const pJsonPath = path.resolve(p, "package.json");
             const pJson = await readPackageJson(pJsonPath);
 
-            if (!pJson) {
+            if (!pJson || pJson.private) {
               continue;
             }
 
             if (!pJson.name) {
               throw new Error(`"name" field in ${pJsonPath} should be defined`);
-            }
-            if (pJson.private) {
-              continue;
             }
 
             const packageName = pJson.name;
@@ -471,14 +468,14 @@ const main = defineCommand({
             }
 
             try {
+              if (pJson.private) {
+                console.warn(`skipping ${p} because the package is private`);
+                continue;
+              }
               if (!pJson.name) {
                 throw new Error(
                   `"name" field in ${pJsonPath} should be defined`,
                 );
-              }
-              if (pJson.private) {
-                console.warn(`skipping ${p} because the package is private`);
-                continue;
               }
 
               const { filename, shasum } = await resolveTarball(

--- a/playgrounds/private-playground/package.json
+++ b/playgrounds/private-playground/package.json
@@ -1,0 +1,3 @@
+{
+  "private": true
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,8 @@ importers:
         specifier: link:../playground-a
         version: link:../playground-a
 
+  playgrounds/private-playground: {}
+
   templates/example-1:
     dependencies:
       pkg-pr-new:


### PR DESCRIPTION
Packages with `"private": true` are already skipped, but currently the `name` check happens first, so if a private package doesn't have a name an error is thrown.

This PR swaps the order of those checks. We don't need a name for private packages.

I've also added a test case.