### PR TITLE
chore: output debug info display pkg.pr.new version

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -621,6 +621,10 @@ const main = defineCommand({
           }
 
           const debug = laterRes.debug;
+          // include the new version in the debug output for better visibility
+          Object.assign(debug, {
+            pkgPrNewVersion: pkg.version,
+          })
 
           core.startGroup("🔍 Info");
           core.notice(JSON.stringify(debug, null, 2));

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -624,7 +624,7 @@ const main = defineCommand({
           // include the new version in the debug output for better visibility
           Object.assign(debug, {
             pkgPrNewVersion: pkg.version,
-          })
+          });
 
           core.startGroup("🔍 Info");
           core.notice(JSON.stringify(debug, null, 2));


### PR DESCRIPTION
The debug information output displays the version number pkg.pr.new, making it easy to quickly check and confirm whether the app version can be used for certain new features.