### PR TITLE
chore: add voidzero-dev/vite-plus to whitelist

### DIFF
--- a/.whitelist
+++ b/.whitelist
@@ -19,3 +19,4 @@ CopilotKit/CopilotKit
 clerk/javascript
 resend/react-email
 larksuite/cli
+voidzero-dev/vite-plus


### PR DESCRIPTION
## Summary

Requesting multipart upload access for the [vite-plus](https://github.com/voidzero-dev/vite-plus) monorepo.

The vite-plus pkg.pr.new publish step uploads multiple workspace packages plus per-platform native addons and CLI binaries, and the combined payload exceeds the non-multipart size limit. The publish currently fails with:

> `Multipart uploads are only accessible to those who are in the whitelist!`

Adding `voidzero-dev/vite-plus` to `.whitelist` so preview publishes can succeed.

---

Please note https://npmx.dev/package/vite-plus is around 120MB and uploads many packages.

To reduce resource contraint on pkg.pr.new servers, we will only publish from branches for testing purposes and will not upload on each commit from main.

Feel free to reject this request.