### PR TITLE
feat: return `commentId` output

### DIFF
--- a/packages/app/server/routes/publish.post.ts
+++ b/packages/app/server/routes/publish.post.ts
@@ -280,6 +280,8 @@ export default eventHandler(async (event) => {
       checkRunUrl = html_url!;
     }
 
+    let commentId: number | undefined;
+
     if (
       isPullRequest(workflowData.ref) &&
       (await getPullRequestState(installation, workflowData)) === "open"
@@ -332,7 +334,7 @@ export default eventHandler(async (event) => {
 
         try {
           if (comment === "update" && prevComment!) {
-            await installation.request(
+            const { data } = await installation.request(
               "PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}",
               {
                 owner: workflowData.owner,
@@ -341,8 +343,9 @@ export default eventHandler(async (event) => {
                 body,
               },
             );
+            commentId = data.id;
           } else {
-            await installation.request(
+            const { data } = await installation.request(
               "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
               {
                 owner: workflowData.owner,
@@ -351,6 +354,7 @@ export default eventHandler(async (event) => {
                 body,
               },
             );
+            commentId = data.id;
           }
         } catch (error) {
           console.error("failed to create/update comment", error, permissions);
@@ -368,6 +372,7 @@ export default eventHandler(async (event) => {
     return {
       ok: true,
       urls,
+      commentId,
       debug: {
         workflowData,
         key,

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -659,7 +659,13 @@ const main = defineCommand({
             await fs.writeFile(jsonFilePath, output);
             console.warn(`metadata written to ${jsonFilePath}`);
           }
-
+          if (laterRes.commentId !== undefined) {
+            await fs.appendFile(
+              GITHUB_OUTPUT,
+              `commentId=${laterRes.commentId}\n`,
+              "utf8",
+            );
+          }
           await fs.appendFile(GITHUB_OUTPUT, `sha=${formattedSha}\n`, "utf8");
           await fs.appendFile(
             GITHUB_OUTPUT,


### PR DESCRIPTION
I'd like to use this to make small edits to the posted comment within my workflow - which is a more lightweight solution to customizing this for certain use cases instead of going full in with customization like this: https://github.com/stackblitz-labs/pkg.pr.new#custom-github-messages-and-comments