### PR TITLE
chore: add supabase/cli to whitelist

### DIFF
--- a/.whitelist
+++ b/.whitelist
@@ -20,3 +20,4 @@ clerk/javascript
 resend/react-email
 larksuite/cli
 voidzero-dev/vite-plus
+supabase/cli


### PR DESCRIPTION
## Summary

Requesting multipart upload access for the `supabase/cli` repository.

The Supabase CLI pkg.pr.new publish step uploads the `supabase` package together with per-platform CLI binary wrapper packages, and the combined payload exceeds the non-multipart size limit. The publish currently fails with:

> `Multipart uploads are only accessible to those who are in the whitelist!`

Adding `supabase/cli` to `.whitelist` so preview publishes can succeed.

---

The preview workflow publishes from pull requests for testing CLI changes before merge.
