### PR TITLE
fix: resolve workspace deps in publishConfig.directory package.json (#389)

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -589,15 +589,16 @@ const main = defineCommand({
               continue;
             }
 
-            // `pack` publishes the package.json from publishConfig.directory when set, so rewrite
-            // the deps in that built package.json rather than the source one — otherwise its
+            // `pnpm pack` publishes the package.json from publishConfig.directory when set, so
+            // rewrite the deps in that built package.json rather than the source one — otherwise its
             // workspace:/link: specifiers get resolved to plain versions instead of pkg.pr.new URLs.
+            // Only pnpm honors publishConfig.directory; npm/yarn/bun pack the source dir as-is.
             // See https://github.com/stackblitz-labs/pkg.pr.new/issues/389
             let depDir = p;
             let depContents = pJsonContents;
             let depJson = pJson;
             const publishDir = pJson.publishConfig?.directory;
-            if (typeof publishDir === "string") {
+            if (packMethod === "pnpm" && typeof publishDir === "string") {
               const builtDir = path.resolve(p, publishDir);
               const builtContents = await tryReadFile(
                 path.resolve(builtDir, "package.json"),
@@ -609,6 +610,11 @@ const main = defineCommand({
                 depDir = builtDir;
                 depContents = builtContents;
                 depJson = builtJson;
+              } else {
+                console.warn(
+                  `Could not read ${path.join(publishDir, "package.json")} for ${pJson.name}; ` +
+                    `its workspace dependencies may not be rewritten to pkg.pr.new URLs.`,
+                );
               }
             }
 

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -922,23 +922,41 @@ async function writeDeps(
   realDeps: Map<string, string> | null,
   newVersion: string | null,
 ) {
-  const pJsonPath = path.resolve(p, "package.json");
+  // When publishConfig.directory is set, `pack` publishes the package.json from that directory,
+  // not this one. That built package.json still holds the original workspace:/link: specifiers,
+  // so the dependency rewriting has to target it — otherwise the packed tarball ships resolved
+  // versions instead of pkg.pr.new URLs. See https://github.com/stackblitz-labs/pkg.pr.new/issues/389
+  let targetPath = path.resolve(p, "package.json");
+  let targetContents = pJsonContents;
+  let targetJson = pJson;
 
-  hijackDeps(deps, pJson.dependencies);
-  hijackDeps(deps, pJson.devDependencies);
-  hijackDeps(deps, pJson.optionalDependencies);
+  const publishDir = pJson.publishConfig?.directory;
+  if (typeof publishDir === "string") {
+    const builtPath = path.resolve(p, publishDir, "package.json");
+    const builtContents = await tryReadFile(builtPath);
+    const builtJson = builtContents ? parsePackageJson(builtContents) : null;
+    if (builtContents && builtJson) {
+      targetPath = builtPath;
+      targetContents = builtContents;
+      targetJson = builtJson;
+    }
+  }
+
+  hijackDeps(deps, targetJson.dependencies);
+  hijackDeps(deps, targetJson.devDependencies);
+  hijackDeps(deps, targetJson.optionalDependencies);
 
   if (realDeps) {
-    hijackDeps(realDeps, pJson.peerDependencies);
+    hijackDeps(realDeps, targetJson.peerDependencies);
   }
 
   if (newVersion) {
-    pJson.version = newVersion;
+    targetJson.version = newVersion;
   }
 
-  await writePackageJSON(pJsonPath, pJson);
+  await writePackageJSON(targetPath, targetJson);
 
-  return () => fs.writeFile(pJsonPath, pJsonContents);
+  return () => fs.writeFile(targetPath, targetContents);
 }
 
 function hijackDeps(

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -589,12 +589,35 @@ const main = defineCommand({
               continue;
             }
 
+            // `pack` publishes the package.json from publishConfig.directory when set, so rewrite
+            // the deps in that built package.json rather than the source one — otherwise its
+            // workspace:/link: specifiers get resolved to plain versions instead of pkg.pr.new URLs.
+            // See https://github.com/stackblitz-labs/pkg.pr.new/issues/389
+            let depDir = p;
+            let depContents = pJsonContents;
+            let depJson = pJson;
+            const publishDir = pJson.publishConfig?.directory;
+            if (typeof publishDir === "string") {
+              const builtDir = path.resolve(p, publishDir);
+              const builtContents = await tryReadFile(
+                path.resolve(builtDir, "package.json"),
+              );
+              const builtJson = builtContents
+                ? parsePackageJson(builtContents)
+                : null;
+              if (builtContents && builtJson) {
+                depDir = builtDir;
+                depContents = builtContents;
+                depJson = builtJson;
+              }
+            }
+
             restoreMap.set(
               p,
               await writeDeps(
-                p,
-                pJsonContents,
-                pJson,
+                depDir,
+                depContents,
+                depJson,
                 deps,
                 realDeps,
                 previewVersion,
@@ -922,41 +945,23 @@ async function writeDeps(
   realDeps: Map<string, string> | null,
   newVersion: string | null,
 ) {
-  // When publishConfig.directory is set, `pack` publishes the package.json from that directory,
-  // not this one. That built package.json still holds the original workspace:/link: specifiers,
-  // so the dependency rewriting has to target it — otherwise the packed tarball ships resolved
-  // versions instead of pkg.pr.new URLs. See https://github.com/stackblitz-labs/pkg.pr.new/issues/389
-  let targetPath = path.resolve(p, "package.json");
-  let targetContents = pJsonContents;
-  let targetJson = pJson;
+  const pJsonPath = path.resolve(p, "package.json");
 
-  const publishDir = pJson.publishConfig?.directory;
-  if (typeof publishDir === "string") {
-    const builtPath = path.resolve(p, publishDir, "package.json");
-    const builtContents = await tryReadFile(builtPath);
-    const builtJson = builtContents ? parsePackageJson(builtContents) : null;
-    if (builtContents && builtJson) {
-      targetPath = builtPath;
-      targetContents = builtContents;
-      targetJson = builtJson;
-    }
-  }
-
-  hijackDeps(deps, targetJson.dependencies);
-  hijackDeps(deps, targetJson.devDependencies);
-  hijackDeps(deps, targetJson.optionalDependencies);
+  hijackDeps(deps, pJson.dependencies);
+  hijackDeps(deps, pJson.devDependencies);
+  hijackDeps(deps, pJson.optionalDependencies);
 
   if (realDeps) {
-    hijackDeps(realDeps, targetJson.peerDependencies);
+    hijackDeps(realDeps, pJson.peerDependencies);
   }
 
   if (newVersion) {
-    targetJson.version = newVersion;
+    pJson.version = newVersion;
   }
 
-  await writePackageJSON(targetPath, targetJson);
+  await writePackageJSON(pJsonPath, pJson);
 
-  return () => fs.writeFile(targetPath, targetContents);
+  return () => fs.writeFile(pJsonPath, pJsonContents);
 }
 
 function hijackDeps(


### PR DESCRIPTION
Reopens #389. `pack` publishes the `package.json` inside `publishConfig.directory`, but `writeDeps` only rewrote the source one so the built one kept its `workspace:`/`link:` specifiers and `pack` resolved them to plain versions instead of pkg.pr.new URLs.

#499 only changed the tarball destination, not which `package.json` gets rewritten, so the bug persisted (repro'd on `0.0.78`).

Fix: rewrite the `package.json` inside `publishConfig.directory` when set, falling back to the source one.