### PR TITLE
fix(app): inline entities in Nitro bundle

### DIFF
--- a/packages/app/nuxt.config.ts
+++ b/packages/app/nuxt.config.ts
@@ -58,6 +58,7 @@ export default defineNuxtConfig({
         "@simulacrum",
         "@jsdevtools",
         "consola",
+        "entities",
         "nuxt-site-config",
       ],
     },


### PR DESCRIPTION
## Summary

- Inline the `entities` package in the Nitro server bundle
- Prevent `entities/lib/decode.js` from resolving to an incompatible hoisted version
- Fix the Nuxt development server worker initialization failure and resulting 503 response

## Verification

- Confirmed the Nitro server bundle builds successfully
- Confirmed the development server returns `200 OK`